### PR TITLE
Changed import paths to remove unused fmt (compile time error) and requi...

### DIFF
--- a/base58check.go
+++ b/base58check.go
@@ -4,8 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
-	"hellobitcoin/base58"
+	"github.com/prettymuchbryce/hellobitcoin/base58"
 	"log"
 	"math/big"
 )


### PR DESCRIPTION
...red full path for go get for base58

Was trying to "go run keys.go base58check.go" to generate keys and ran into two small issues:
- Import path needed to be the full "github.com/prettymuchbryce/hellobitcoin/base58" to run go get (assuming people are using go get to grab github.com/prettymuchbryce/hellobitcoin in the first place)
- Removed unused "fmt" here to fix a compile time error
