### PR TITLE
Added optional flag to specify output index in unspent input transaction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,15 @@ These programs are not "crytographically" random, and should not be used for any
 
 	go run transaction.go base58check.go
 	
-	options (all are required)
+	options (required)
 	--private-key yourPrivateKey
 	--public-key yourPublicKey
 	--destination destinationPublicKey
 	--input-transaction inputTransactionHash
 	--satoshis satoshisToSend
+
+	options (optional)
+	--input-index inputTransactionIndex
 
 
 ##### Sending a transaction over the bitcoin network


### PR DESCRIPTION
My justification is that the input transaction used may have been created by any Bitcoin implementation, including those other than hellobitcoin, and may have had multiple outputs. This change adds an optional flag to let users generate transactions specify UTXOs that are not at the first index of the input transaction.  Defaults to 0 (first index), so no added complexity is created for the user here if they want to ignore this flag.

New flag documented in README.

Hope this is helpful :)
Soroush
